### PR TITLE
Change deployment environment to staging

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     if: github.ref == 'refs/heads/master'
-    environment: production            # Use production here if you want approvals before deploying to staging
+    environment: staging            # Use production here if you want approvals before deploying to staging
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Updated the "Deploy to Staging Slot" job in the
`ci-cd.yml` file to target the staging environment instead of production.