### PR TITLE
Update Google AdSense client ID in production

### DIFF
--- a/My-Ai/Components/App.razor
+++ b/My-Ai/Components/App.razor
@@ -31,7 +31,7 @@
     @if (Env.IsProduction())
     {
         <!-- Google AdSense (only in Production) -->
-        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9127498419225547"
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9488876943278355"
                 crossorigin="anonymous"></script>
     }
 


### PR DESCRIPTION
Replaced the existing AdSense script tag with a new one using a different client ID (ca-pub-9488876943278355) to reflect a switch in AdSense account or configuration while maintaining ad functionality in production.